### PR TITLE
Redirect distroless.dev/static to github.com/distroless/static

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,10 @@ func main() {
 	// TODO(jason): Configure this more generally.
 	if *repo == "distroless" {
 		http.Handle("/new", http.RedirectHandler("https://github.com/"+*repo+"/template/generate", http.StatusSeeOther))
-		http.Handle("/", http.RedirectHandler("https://github.com/"+*repo, http.StatusSeeOther))
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			url := "https://github.com/distroless" + r.URL.Path
+			http.Redirect(w, r, url, http.StatusSeeOther)
+		})
 	}
 
 	logger.Info("Starting...")


### PR DESCRIPTION
...instead of `distroless.dev/static` redirecting to https://github.com/distroless

