### PR TITLE
Support customizing user-visible repo prefix

### DIFF
--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -13,18 +13,6 @@ trap 'kill $PID' EXIT
 
 sleep 3  # Server isn't immediately ready.
 
-got=$(curl http://localhost:8080/v2/ --write-out '%{http_code}')
-[[ ! "$got" =~ "401" ]] && { echo "expected 401 from /v2/, got $got"; exit 1; }
-
-got=$(curl -I HEAD http://localhost:8080/v2/nginx/manifests/latest --write-out "%{http_code}")
-[[ ! "$got" =~ "405" ]] && { echo "expected 405 from HEAD /v2/nginx/manifests/latest, got $got"; exit 1; }
-
-got=$(curl -H "Accept: application/vnd.oci.image.index.v1+json" http://localhost:8080/v2/nginx/manifests/latest --write-out "%{http_code}")
-[[ ! "$got" =~ "200" ]] && { echo "expected 200 from /v2/nginx/manifests/latest, got $got"; exit 1; }
-
-got=$(curl http://localhost:8080/v2/nginx/tags/list --write-out "%{http_code}")
-[[ ! "$got" =~ "200" ]] && { echo "expected 200 from /v2/nginx/tags/list, got $got"; exit 1; }
-
 crane digest localhost:8080/nginx
 crane manifest localhost:8080/nginx
 crane ls localhost:8080/nginx
@@ -32,4 +20,4 @@ crane ls localhost:8080/nginx
 # TODO(jason): docker pull an image through the redirector.
 
 # TODO(jason): Run the redirector as a container connected to a kind cluster
-# and pull through the redirector 
+# and pull through the redirector

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -6,7 +6,7 @@ crane version >/dev/null \
   || { echo "install crane: https://github.com/google/go-containerregistry/blob/main/cmd/crane"; exit 1; }
 
 # Run the redirector in the background, kill it when the script exits.
-go build && ./registry-redirect &
+go build && ./registry-redirect --prefix=unicorns &
 PID=$!
 echo "server running with pid $PID"
 trap 'kill $PID' EXIT
@@ -16,6 +16,10 @@ sleep 3  # Server isn't immediately ready.
 crane digest localhost:8080/nginx
 crane manifest localhost:8080/nginx
 crane ls localhost:8080/nginx
+
+crane digest localhost:8080/unicorns/nginx
+crane manifest localhost:8080/unicorns/nginx
+crane ls localhost:8080/unicorns/nginx
 
 # TODO(jason): docker pull an image through the redirector.
 

--- a/main.go
+++ b/main.go
@@ -222,8 +222,9 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 		url += *repo + "/"
 	}
 	path := strings.TrimPrefix(r.URL.Path, "/v2/")
-	if !strings.HasPrefix(path, *prefix+"/") {
+	if *prefix != "" && !strings.HasPrefix(path, *prefix+"/") {
 		http.Error(w, "not found", http.StatusNotFound)
+		return
 	}
 	path = strings.TrimPrefix(path, *prefix+"/")
 	url += path + "?" + r.URL.Query().Encode()
@@ -334,7 +335,7 @@ func getToken(r *http.Request) (string, *http.Response, error) {
 	} else {
 		url = fmt.Sprintf("https://ghcr.io/token?scope=repository:%s:pull&service=ghcr.io", strings.Join(parts, "/"))
 	}
-	req, _ := http.NewRequest(r.Method, url, nil)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	req.Header = r.Header.Clone()
 	resp, err := http.DefaultClient.Do(req) //nolint:gosec
 	if err != nil {


### PR DESCRIPTION
This lets us customize the repo name component of user-visible repo names:

Previously:
```
go run ./
...
$ crane manifest localhost:8080/static
<... manifest for ghcr.io/distroless/static ...>
```

With this change:

```
go run ./ --prefix=unicorns
$ crane manifest localhost:8080/unicorns/static
<... manifest for ghcr.io/distroless/static ...>

$ crane manifest localhost:8080/static
Error: fetching manifest localhost:8080/static: GET http://localhost:8080/v2/static/manifests/latest: unexpected status code 404 Not Found: not found
```

`distroless.dev` will continue to run without the `--prefix` option set, since folks will get images from `distroless.dev/static` without the prefix.