### PR TITLE
Support new cgr.dev domain

### DIFF
--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -13,10 +13,6 @@ trap 'kill $PID' EXIT
 
 sleep 3  # Server isn't immediately ready.
 
-crane digest localhost:8080/nginx
-crane manifest localhost:8080/nginx
-crane ls localhost:8080/nginx
-
 crane digest localhost:8080/unicorns/nginx
 crane manifest localhost:8080/unicorns/nginx
 crane ls localhost:8080/unicorns/nginx

--- a/gclb.tf
+++ b/gclb.tf
@@ -25,8 +25,6 @@ resource "random_id" "certificate" {
 }
 
 resource "google_compute_managed_ssl_certificate" "global" {
-  provider = google-beta
-
   name = random_id.certificate.hex
   managed {
     domains = var.domains
@@ -55,18 +53,15 @@ resource "google_compute_global_forwarding_rule" "global" {
 }
 
 resource "google_compute_url_map" "global" {
-  provider = google-beta
-
   name            = "global"
   description     = "direct traffic to the backend service"
   default_service = google_compute_backend_service.global.id
 }
 
 resource "google_compute_target_https_proxy" "global" {
-  provider = google-beta
+  name    = "global"
+  url_map = google_compute_url_map.global.id
 
-  name             = "global"
-  url_map          = google_compute_url_map.global.id
   ssl_certificates = [google_compute_managed_ssl_certificate.global.id]
 }
 

--- a/new_cert.tf
+++ b/new_cert.tf
@@ -16,7 +16,7 @@ resource "google_certificate_manager_dns_authorization" "this" {
   for_each = toset(var.new_domains)
   name     = replace("${each.key}", ".", "-")
   domain   = each.key
-  labels = {}
+  labels   = {}
 }
 
 resource "google_certificate_manager_certificate" "cert" {

--- a/new_cert.tf
+++ b/new_cert.tf
@@ -1,0 +1,53 @@
+variable "new_domains" {
+  type = list(string)
+  default = [
+    "cgr.dev",
+    "distroless.dev",
+    "images.wolfi.dev",
+  ]
+}
+
+// Enable Certificate Manager API.
+resource "google_project_service" "certmanager" {
+  service = "certificatemanager.googleapis.com"
+}
+
+resource "google_certificate_manager_dns_authorization" "this" {
+  for_each = toset(var.new_domains)
+  name     = replace("${each.key}", ".", "-")
+  domain   = each.key
+  labels = {}
+}
+
+resource "google_certificate_manager_certificate" "cert" {
+  for_each = toset(var.new_domains)
+
+  name  = replace("${each.key}", ".", "-")
+  scope = "DEFAULT"
+
+  managed {
+    domains = [each.key]
+    dns_authorizations = [
+      google_certificate_manager_dns_authorization.this[each.key].id
+    ]
+  }
+
+  depends_on = [google_project_service.certmanager]
+}
+
+resource "google_certificate_manager_certificate_map" "map" {
+  name = "cert-map"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "map_entry" {
+  for_each = toset(var.new_domains)
+
+  name     = replace("certificatemapentry-${each.key}", ".", "-")
+  map      = google_certificate_manager_certificate_map.map.name
+  hostname = each.key
+
+  certificates = [
+    google_certificate_manager_certificate.cert[each.key].id
+  ]
+}
+

--- a/new_gclb.tf
+++ b/new_gclb.tf
@@ -1,0 +1,103 @@
+// Reserve a global static IP address.
+resource "google_compute_global_address" "new_global" {
+  name = "new-address"
+}
+
+output "new_global_ip" {
+  value = google_compute_global_address.new_global.address
+}
+
+resource "google_compute_global_forwarding_rule" "new_global" {
+  name       = "new-global"
+  target     = google_compute_target_https_proxy.new_global.id
+  port_range = "443"
+  ip_address = google_compute_global_address.new_global.address
+}
+
+resource "google_compute_url_map" "new_global" {
+  name            = "new-global"
+  description     = "direct traffic to the backend service"
+  default_service = google_compute_backend_service.new_global.id
+
+  host_rule {
+    hosts        = var.new_domains
+    path_matcher = "matcher"
+  }
+
+  path_matcher {
+    name = "matcher"
+
+    # Match /v2/ and /token and send to the backend service.
+    path_rule {
+      paths   = ["/v2", "/v2/*", "/token"]
+      service = google_compute_backend_service.new_global.id
+    }
+
+    # Match all other path and redirect to the Chainguard Images marketing page.
+    # See also:
+    # https://cloud.google.com/load-balancing/docs/https/setting-up-global-traffic-mgmt#configure_a_url_redirect
+    default_url_redirect {
+      host_redirect          = "chainguard.dev"
+      https_redirect         = false
+      path_redirect          = "/chainguard-images"
+      redirect_response_code = "TEMPORARY_REDIRECT"
+      strip_query            = true
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.new_global.id
+    host    = "cgr.dev"
+    path    = "/v2/chainguard/static/manifests/latest"
+  }
+
+  test {
+    service = google_compute_backend_service.new_global.id
+    host    = "distroless.dev"
+    path    = "/v2/static/manifests/latest"
+  }
+}
+
+resource "google_compute_target_https_proxy" "new_global" {
+  name    = "new-global"
+  url_map = google_compute_url_map.new_global.id
+
+  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map.id}"
+}
+
+// Create a global backend service with a backend for each regional NEG.
+resource "google_compute_backend_service" "new_global" {
+  name       = "new-global"
+  enable_cdn = true
+
+  # Inject some request headers based on detected client information.
+  # See https://cloud.google.com/load-balancing/docs/https/custom-headers#variables
+  custom_request_headers = [
+    "x-client-rtt: {client_rtt_msec}",
+    "x-client-region: {client_region}",
+    "x-client-region-subdivision: {client_region_subdivision}",
+    "x-client-city: {client_city}",
+  ]
+
+  # Log a sample of requests which we can query later.
+  log_config {
+    enable      = true
+    sample_rate = 0.1
+  }
+
+  // Add a backend for each regional NEG.
+  dynamic "backend" {
+    for_each = google_compute_region_network_endpoint_group.neg
+    content {
+      group = backend.value["id"]
+    }
+  }
+}
+
+resource "google_compute_global_forwarding_rule" "new_https_redirect" {
+  name = "new-https-redirect"
+
+  target     = google_compute_target_http_proxy.https_redirect.id
+  port_range = "80"
+  ip_address = google_compute_global_address.new_global.address
+}

--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -7,6 +7,8 @@ package redirect_test
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -52,6 +54,41 @@ func TestRedirect(t *testing.T) {
 				if _, err := crane.ListTags(ref); err != nil {
 					t.Errorf("listing tags: %v", err)
 				}
+			}
+		})
+	}
+}
+
+func TestPrefixlessHosts(t *testing.T) {
+	for _, c := range []struct {
+		desc    string
+		reqHost string
+		repo    string
+		wantErr bool
+	}{
+		{"cgr with prefix", "cgr.dev", "chainguard/static", false},
+		{"cgr without prefix", "cgr.dev", "static", true},
+		{"distroless with prefix", "distroless.dev", "chainguard/static", true},
+		{"distroless without prefix", "distroless.dev", "static", false},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			s := httptest.NewServer(redirect.New("ghcr.io", "distroless", "chainguard"))
+			defer s.Close()
+
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v2/%s/tags/list", s.URL, c.repo), nil)
+			if err != nil {
+				t.Fatalf("creating request: %v", err)
+			}
+			req.Host = c.reqHost
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer resp.Body.Close()
+			gotErr := (resp.StatusCode != http.StatusOK)
+			if gotErr != c.wantErr {
+				all, _ := io.ReadAll(resp.Body)
+				t.Errorf("got error %v, want %v; %s", gotErr, c.wantErr, string(all))
 			}
 		})
 	}

--- a/redirect.tf
+++ b/redirect.tf
@@ -6,11 +6,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "4.26.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "4.26.0"
+      version = "~> 4.36.0"
     }
   }
 }
@@ -22,16 +18,8 @@ provider "ko" {
 variable "project" {
   type = string
 }
-variable "region" {
-  type    = string
-  default = "us-east4"
-}
 
 provider "google" {
-  project = var.project
-}
-
-provider "google-beta" {
   project = var.project
 }
 
@@ -68,6 +56,10 @@ resource "google_cloud_run_service" "regions" {
           name  = "REGION"
           value = each.key
         }
+        args = [
+          "--prefix",
+          "chainguard",
+        ]
       }
       service_account_name  = google_service_account.sa.email
       container_concurrency = 1000
@@ -77,6 +69,10 @@ resource "google_cloud_run_service" "regions" {
     percent         = 100
     latest_revision = true
   }
+
+  // This is supposed to prevent permanent "Still modifying..." states.
+  // See https://github.com/hashicorp/terraform-provider-google/issues/9438
+  autogenerate_revision_name = true
 
   depends_on = [google_project_service.run]
 }


### PR DESCRIPTION
- cgr.dev/chainguard/static redirects to ghcr.io/distroless/static
- Go code strips the "chainguard" prefix
- distroless.dev/static still redirects to ghcr.io/distroless/static
- new global IP, GCLB, SSL certs just for cgr.dev, with parallel structure for distroless.dev and images.wolfi.dev so we can cut over using DNS
- add a fallback URL redirect for anything that isn't /v2 or /token, to redirect to Chainguard Images marketing page