### PR TITLE
fix next header rewrite for prefixless hosts

### DIFF
--- a/pkg/redirect/redirect.go
+++ b/pkg/redirect/redirect.go
@@ -263,7 +263,7 @@ func (rdr redirect) proxy(w http.ResponseWriter, r *http.Request) {
 				log.Println("=== BEFORE: Link:", vv)
 				rest := strings.TrimPrefix(vv, "</v2/"+rdr.repo)
 				vv = "</v2" + rest
-				if rdr.prefix != "" {
+				if rdr.prefix != "" && !prefixlessHosts[r.Host] {
 					vv = "</v2/" + rdr.prefix + rest
 				}
 				log.Println("=== CHANGED: Link:", vv)

--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -92,7 +92,7 @@ func TestPrefixlessHosts(t *testing.T) {
 			}
 
 			link := resp.Header.Get("Link")
-			if strings.Contains(link, `; rel="next"`) {
+			if strings.Contains(link, `>; rel="next"`) {
 				t.Logf("got Link next header: %s", resp.Header.Get("Link"))
 				next := strings.TrimPrefix(link, "<")
 				next = next[:strings.Index(next, ">")]

--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -90,6 +90,8 @@ func TestPrefixlessHosts(t *testing.T) {
 				all, _ := io.ReadAll(resp.Body)
 				t.Errorf("got error %v, want %v; %s", gotErr, c.wantErr, string(all))
 			}
+
+			t.Logf("got Link next header: %s", resp.Header.Get("Link"))
 		})
 	}
 }


### PR DESCRIPTION
When there was a second page of tags requested through distroless.dev, the `Next` header included the prefix when it shouldn't have, leading to broken `crane ls`es.

This fixes that.