### PR TITLE
return correct content-length header

### DIFF
--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -86,9 +86,12 @@ func TestPrefixlessHosts(t *testing.T) {
 			}
 			defer resp.Body.Close()
 			gotErr := (resp.StatusCode != http.StatusOK)
+			all, _ := io.ReadAll(resp.Body)
 			if gotErr != c.wantErr {
-				all, _ := io.ReadAll(resp.Body)
 				t.Errorf("got error %v, want %v; %s", gotErr, c.wantErr, string(all))
+			}
+			if resp.ContentLength >= 0 && int(resp.ContentLength) != len(all) {
+				t.Errorf("got %d bytes, want %d", len(all), resp.ContentLength)
 			}
 
 			link := resp.Header.Get("Link")
@@ -108,6 +111,10 @@ func TestPrefixlessHosts(t *testing.T) {
 				}
 				if resp.StatusCode != http.StatusOK {
 					t.Errorf("listing next page; got status %v, want %v", resp.StatusCode, http.StatusOK)
+				}
+				all, _ := io.ReadAll(resp.Body)
+				if resp.ContentLength >= 0 && int(resp.ContentLength) != len(all) {
+					t.Errorf("got %d bytes, want %d", len(all), resp.ContentLength)
 				}
 			}
 		})


### PR DESCRIPTION
When we rewrite the `/tags/list` response to include the correct user-visible repo name, we did so after setting the `Content-Length` response header to the upstream response's length. This meant that we were responding with less data than we promised clients.

Most of the time this was okay, but in some cases it seems like Cloud Run failed when it saw a shorter-than-expected response -- seemingly only on very _small_ responses 🤔, which is why we didn't catch this earlier. Cloud Run's behavior in this case was to respond to clients with zero bytes, leading to `EOF` errors on, e.g., `crane ls distroless.dev/nginx`.

This only happened in Cloud Run, only on `/tags/list` responses, and only on some shorter-than-some-buffer-size responses, so typically only happened on the last page of list results.