### PR TITLE
redirect image URLs to useful GitHub READMEs

### DIFF
--- a/new_gclb.tf
+++ b/new_gclb.tf
@@ -27,9 +27,9 @@ resource "google_compute_url_map" "new_global" {
   path_matcher {
     name = "matcher"
 
-    # Match /v2/ and /token and send to the backend service.
+    # Match /v2/* and /token and /chainguard/* and send to the backend service.
     path_rule {
-      paths   = ["/v2", "/v2/*", "/token"]
+      paths   = ["/v2", "/v2/*", "/token", "/chainguard/*"]
       service = google_compute_backend_service.new_global.id
     }
 
@@ -49,6 +49,12 @@ resource "google_compute_url_map" "new_global" {
     service = google_compute_backend_service.new_global.id
     host    = "cgr.dev"
     path    = "/v2/chainguard/static/manifests/latest"
+  }
+
+  test {
+    service = google_compute_backend_service.new_global.id
+    host    = "cgr.dev"
+    path    = "/chainguard/static:latest"
   }
 
   test {

--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -59,6 +59,34 @@ func TestRedirect(t *testing.T) {
 	}
 }
 
+func TestGHPageRedirect(t *testing.T) {
+	s := httptest.NewServer(redirect.New("ghcr.io", "chainguard-images", "chainguard"))
+
+	for _, path := range []string{
+		"/chainguard/busybox",
+		"/chainguard/busybox:latest",
+		"/chainguard/busybox@sha256:abcdef",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, s.URL+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := resp.Location()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := got.String(), "https://github.com/chainguard-images/images/blob/main/images/busybox"; got != want {
+				t.Fatalf("Got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestPrefixlessHosts(t *testing.T) {
 	for _, c := range []struct {
 		desc    string

--- a/redirect.tf
+++ b/redirect.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     ko = {
-      source  = "chainguard-dev/ko"
-      version = "0.0.2"
+      source = "ko-build/ko"
     }
     google = {
       source  = "hashicorp/google"
@@ -12,7 +11,7 @@ terraform {
 }
 
 provider "ko" {
-  docker_repo = "gcr.io/${var.project}"
+  repo = "gcr.io/${var.project}"
 }
 
 variable "project" {


### PR DESCRIPTION
Today, if you load an image URL in the browser, (e.g. https://cgr.dev/chainguard/static) it redirects to our marketing page: https://www.chainguard.dev/chainguard-images

It's beautiful, no doubt, but it's not very useful if you came there hoping to find out more about that specific image.

With this change this URL will instead redirect to the equivalent GitHub README for the requested image, e.g., https://github.com/chainguard-images/images/blob/main/images/static, where folks can learn more about how to use it, how it was built, etc.

This also cleans up a couple old TF things I noticed while looking through.