### PR TITLE
redirect distroless.dev/foo -> cgr.dev/chainguard/foo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is a simple OCI redirector service that allows for custom domains, including forwarding auth token requests to the original registry.
 
-For example, this is used to serve `distroless.dev/*` as a redirection to `ghcr.io/distroless/*`.
+For example, this is used to serve `distroless.dev/*` as a redirection to `cgr.dev/chainguard/*`.
 
-It's intended to be deployed to Google Cloud Run, which is responsible for handling HTTPS.
+It's intended to be deployed to Google Cloud Run behind a GCLB load balancer, which is responsible for handling HTTPS.
 
 ## Deploying
 
@@ -26,56 +26,4 @@ $ terraform apply -var project=[MY-PROJECT]
 url = "https://redirect-a1b2c3d4-uk.a.run.app"
 ```
 
-This requires permission to push images to GCR, and to deploy Cloud Run services.
-
-This will deploy to `us-east4` -- you can override with `-var region=[MY-REGION]`.
-
-## Auth
-
-To authorize through the redirection step (e.g., to access private images), you can configure credentials for the domain where the redirector is hosted.
-
-This may be a Cloud Run service URL (something like `redirect-a1b2c3d4-uk.a.run.app`) or a mapped domain name.
-
-When used this way, registry credentials are sent to the redirector, and are passed directly on to the real registry.
-Credentials are never stored or logged by the redirector.
-
-### GCR Auth
-
-To configure auth to GCR, you can either:
-
-- download a Service Account's JSON key as described in [GCR docs](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key), or
-- configure the [`docker-credential-gcr` cred helper](https://cloud.google.com/container-registry/docs/advanced-authentication#standalone-helper)
-
-In either case, make sure to configure those creds _for the redirector's domain_, not `*.gcr.io`, e.g.:
-
-```
-cat keyfile.json | docker login redirect-a1b2c3d4-uk.a.run.app -u _json_key --password-stdin
-```
-
-or, in your `~/.docker/config.json`:
-
-```
-{
-  "credHelpers": {
-    "redirect-a1b2c3d4-uk.a.run.app": "gcr",
-  }
-}
-```
-
-This will tell clients to use GCR creds to talk to the redirector, which will be passed through the redirector to GCR when you make requests.
-
-### GHCR Auth
-
-To configure auth to GHCR, you can use a personal access token as described in [GHCR docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
-
-Make sure to configure those creds _for the redirector's domain_, not `ghcr.io`, e.g.:
-
-```
-echo $CR_PAT | docker login redirect-a1b2c3d4-uk.a.run.app -u USERNAME --password-stdin
-```
-
-This will tell clients to use GHCR creds to talk to the redirector, which will be passed through the redirector to GHCR when you make requests.
-
-## Configuration
-
-You can use this to host other redirections, to ghcr.io (the default) or gcr.io (using `--gcr=true`).
+This requires permission to push images to GCR, and to deploy Cloud Run services and create GCP resources.

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -6,18 +6,16 @@ crane version >/dev/null \
   || { echo "install crane: https://github.com/google/go-containerregistry/blob/main/cmd/crane"; exit 1; }
 
 # Run the redirector in the background, kill it when the script exits.
-go build && ./registry-redirect --prefix=unicorns &
+go build && ./registry-redirect &
 PID=$!
 echo "server running with pid $PID"
 trap 'kill $PID' EXIT
 
 sleep 3  # Server isn't immediately ready.
 
-crane digest localhost:8080/unicorns/nginx
-crane manifest localhost:8080/unicorns/nginx
-crane ls localhost:8080/unicorns/nginx
+crane digest localhost:8080/nginx
+crane manifest localhost:8080/nginx
+crane ls localhost:8080/nginx
+crane pull localhost:8080/nginx /dev/null
 
-# TODO(jason): docker pull an image through the redirector.
-
-# TODO(jason): Run the redirector as a container connected to a kind cluster
-# and pull through the redirector
+echo PASSED

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -20,5 +20,6 @@ crane digest localhost:8080/nginx
 crane manifest localhost:8080/nginx
 crane ls localhost:8080/nginx
 crane pull localhost:8080/nginx /dev/null
+crane validate --remote=localhost:8080/nginx
 
 echo PASSED

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -6,7 +6,7 @@ crane version >/dev/null \
   || { echo "install crane: https://github.com/google/go-containerregistry/blob/main/cmd/crane"; exit 1; }
 
 # Kill whatever's running on :8080
-kill -9 $(lsof -ti:8080)
+# kill -9 $(lsof -ti:8080)
 
 # Run the redirector in the background, kill it when the script exits.
 go build && ./registry-redirect &

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -5,6 +5,9 @@ set -euxo pipefail
 crane version >/dev/null \
   || { echo "install crane: https://github.com/google/go-containerregistry/blob/main/cmd/crane"; exit 1; }
 
+# Kill whatever's running on :8080
+kill -9 $(lsof -ti:8080)
+
 # Run the redirector in the background, kill it when the script exits.
 go build && ./registry-redirect &
 PID=$!

--- a/env/jason-chainguard/main.tf
+++ b/env/jason-chainguard/main.tf
@@ -21,10 +21,7 @@ module "bq" {
 module "gclb" {
   source = "../../terraform/modules/gclb"
 
-  project       = var.project
-  regions       = var.regions
-  domains = [
-    "redirect.imjasonh.dev",
-  ]
-  primary_domain = "redirect.imjasonh.dev"
+  project = var.project
+  regions = var.regions
+  domain  = "redirect.imjasonh.dev"
 }

--- a/env/production/main.tf
+++ b/env/production/main.tf
@@ -21,11 +21,7 @@ module "bq" {
 module "gclb" {
   source = "../../terraform/modules/gclb"
 
-  project       = var.project
-  regions       = var.regions
-  domains = [
-    "cgr.dev",
-    "distroless.dev",
-  ]
-  primary_domain = "cgr.dev"
+  project = var.project
+  regions = var.regions
+  domain  = "distroless.dev"
 }

--- a/main.go
+++ b/main.go
@@ -16,40 +16,11 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// TODO:
-// - Also support anonymous and Basic-type auth?
-// - take a config for registries/repos to redirect from/to.
-
-var (
-	// Redirect requests for distroless.dev/static -> ghcr.io/distroless/static
-	// If repo is empty, example.dev/foo/bar -> ghcr.io/foo/bar
-	repo = flag.String("repo", "distroless", "repo to redirect to")
-
-	// TODO(jason): Support arbitrary registries.
-	gcr = flag.Bool("gcr", false, "if true, use GCR mode")
-
-	// prefix is the user-visible repo prefix.
-	// For example, if repo is "distroless" and prefix is "unicorns",
-	// users hitting example.dev/unicorns/foo/bar will be redirected to
-	// ghcr.io/distroless/foo/bar.
-	// If prefix is unset, hitting example.dev/unicorns/foo/bar will
-	// redirect to ghcr.io/unicorns/foo/bar.
-	// If prefix is set, and users hit a path without the prefix, it's ignored:
-	// - example.dev/foo/bar -> ghcr.io/distroless/foo/bar
-	// (this is for backward compatibility with prefix-less redirects)
-	prefix = flag.String("prefix", "", "if set, user-visible repo prefix")
-)
-
 func main() {
 	flag.Parse()
 	logger := logging.FromContext(context.Background())
 
-	host := "ghcr.io"
-	if *gcr {
-		host = "gcr.io"
-	}
-	r := redirect.New(host, *repo, *prefix)
-	http.Handle("/", r)
+	http.Handle("/", redirect.New())
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/pkg/redirect/redirect_test.go
+++ b/pkg/redirect/redirect_test.go
@@ -7,7 +7,6 @@ package redirect_test
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,54 +17,39 @@ import (
 )
 
 func TestRedirect(t *testing.T) {
-	for _, c := range []struct{ host, repo, prefix string }{
-		{"ghcr.io", "distroless", ""},
-		{"gcr.io", "jason-chainguard-public", ""},
-		{"ghcr.io", "distroless", "unicorns"},
-		{"gcr.io", "jason-chainguard-public", "unicorns"},
-	} {
-		t.Run(fmt.Sprintf("%s/%s (prefix %s)", c.host, c.repo, c.prefix), func(t *testing.T) {
-			s := httptest.NewServer(redirect.New(c.host, c.repo, c.prefix))
-			defer s.Close()
+	s := httptest.NewServer(redirect.New())
+	defer s.Close()
 
-			reg := strings.TrimPrefix(s.URL, "http://")
-			ref := fmt.Sprintf("%s/static", reg)
-			if c.prefix != "" {
-				ref = fmt.Sprintf("%s/%s/static", reg, c.prefix)
-			}
+	reg := strings.TrimPrefix(s.URL, "http://")
+	ref := fmt.Sprintf("%s/static", reg)
 
-			t.Logf("testing image: %s", ref)
+	t.Logf("testing image: %s", ref)
 
-			if _, err := crane.Digest(ref); err != nil {
-				t.Errorf("digest: %v", err)
-			}
+	if _, err := crane.Digest(ref); err != nil {
+		t.Errorf("digest: %v", err)
+	}
 
-			if _, err := crane.Manifest(ref); err != nil {
-				t.Errorf("manifest: %v", err)
-			}
+	if _, err := crane.Manifest(ref); err != nil {
+		t.Errorf("manifest: %v", err)
+	}
 
-			if _, err := crane.Pull(ref); err != nil {
-				t.Errorf("pulling: %v", err)
-			}
+	if _, err := crane.Pull(ref); err != nil {
+		t.Errorf("pulling: %v", err)
+	}
 
-			// TODO(jason): Listing tags against GCR doesn't work due to gzip;
-			// fix this and re-enable, or remove GCR support.
-			if c.host != "gcr.io" {
-				if _, err := crane.ListTags(ref); err != nil {
-					t.Errorf("listing tags: %v", err)
-				}
-			}
-		})
+	if _, err := crane.ListTags(ref); err != nil {
+		t.Errorf("listing tags: %v", err)
 	}
 }
 
 func TestGHPageRedirect(t *testing.T) {
-	s := httptest.NewServer(redirect.New("ghcr.io", "chainguard-images", "chainguard"))
+	s := httptest.NewServer(redirect.New())
 
 	for _, path := range []string{
-		"/chainguard/busybox",
-		"/chainguard/busybox:latest",
-		"/chainguard/busybox@sha256:abcdef",
+		"/",
+		"/busybox",
+		"/busybox:latest",
+		"/busybox@sha256:abcdef",
 	} {
 		t.Run(path, func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, s.URL+path, nil)
@@ -80,70 +64,8 @@ func TestGHPageRedirect(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got, want := got.String(), "https://github.com/chainguard-images/images/blob/main/images/busybox"; got != want {
+			if got, want := got.String(), "https://cgr.dev/chainguard"+path; got != want {
 				t.Fatalf("Got %q, want %q", got, want)
-			}
-		})
-	}
-}
-
-func TestPrefixlessHosts(t *testing.T) {
-	for _, c := range []struct {
-		desc    string
-		reqHost string
-		repo    string
-		wantErr bool
-	}{
-		{"cgr with prefix", "cgr.dev", "chainguard/static", false},
-		{"cgr without prefix", "cgr.dev", "static", true},
-		{"distroless with prefix", "distroless.dev", "chainguard/static", true},
-		{"distroless without prefix", "distroless.dev", "static", false},
-	} {
-		t.Run(c.desc, func(t *testing.T) {
-			s := httptest.NewServer(redirect.New("ghcr.io", "distroless", "chainguard"))
-			defer s.Close()
-
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v2/%s/tags/list", s.URL, c.repo), nil)
-			if err != nil {
-				t.Fatalf("creating request: %v", err)
-			}
-			req.Host = c.reqHost
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("request: %v", err)
-			}
-			defer resp.Body.Close()
-			gotErr := (resp.StatusCode != http.StatusOK)
-			all, _ := io.ReadAll(resp.Body)
-			if gotErr != c.wantErr {
-				t.Errorf("got error %v, want %v; %s", gotErr, c.wantErr, string(all))
-			}
-			if resp.ContentLength >= 0 && int(resp.ContentLength) != len(all) {
-				t.Errorf("got %d bytes, want %d", len(all), resp.ContentLength)
-			}
-
-			link := resp.Header.Get("Link")
-			if strings.Contains(link, `>; rel="next"`) {
-				t.Logf("got Link next header: %s", resp.Header.Get("Link"))
-				next := strings.TrimPrefix(link, "<")
-				next = next[:strings.Index(next, ">")]
-
-				req, err = http.NewRequest(http.MethodGet, s.URL+next, nil)
-				if err != nil {
-					t.Fatalf("creating request: %v", err)
-				}
-				req.Host = c.reqHost
-				resp, err := http.DefaultClient.Do(req)
-				if err != nil {
-					t.Fatalf("request: %v", err)
-				}
-				if resp.StatusCode != http.StatusOK {
-					t.Errorf("listing next page; got status %v, want %v", resp.StatusCode, http.StatusOK)
-				}
-				all, _ := io.ReadAll(resp.Body)
-				if resp.ContentLength >= 0 && int(resp.ContentLength) != len(all) {
-					t.Errorf("got %d bytes, want %d", len(all), resp.ContentLength)
-				}
 			}
 		})
 	}

--- a/terraform/modules/gclb/cert.tf
+++ b/terraform/modules/gclb/cert.tf
@@ -7,20 +7,17 @@ resource "google_project_service" "certmanager" {
 }
 
 resource "google_certificate_manager_dns_authorization" "this" {
-  for_each = var.domains
-  name     = replace("${each.key}", ".", "-")
-  domain   = each.key
+  name     = replace("${var.domain}", ".", "-")
+  domain   = var.domain
   labels   = {}
 }
 
 resource "google_certificate_manager_certificate" "cert" {
-  for_each = var.domains
-
-  name  = replace("${each.key}", ".", "-")
+  name  = replace("${var.domain}", ".", "-")
   scope = "DEFAULT"
 
   managed {
-    domains = [each.key]
+    domains = [var.domain]
   }
 
   depends_on = [google_project_service.certmanager]
@@ -31,25 +28,11 @@ resource "google_certificate_manager_certificate_map" "map" {
 }
 
 resource "google_certificate_manager_certificate_map_entry" "map_entry" {
-  for_each = var.domains
-
-  name     = replace("certificatemapentry-${each.key}", ".", "-")
-  map      = google_certificate_manager_certificate_map.map.name
-
-  hostname = each.key
-
-  certificates = [
-    google_certificate_manager_certificate.cert[each.key].id
-  ]
-}
-
-resource "google_certificate_manager_certificate_map_entry" "primary_map_entry" {
-  name     = replace("certificatemapentry-${var.primary_domain}-2", ".", "-")
+  name     = replace("certificatemapentry-${var.domain}", ".", "-")
   map      = google_certificate_manager_certificate_map.map.name
   matcher = "PRIMARY"
 
   certificates = [
-    google_certificate_manager_certificate.cert[var.primary_domain].id
+    google_certificate_manager_certificate.cert.id
   ]
 }
-

--- a/terraform/modules/gclb/gclb.tf
+++ b/terraform/modules/gclb/gclb.tf
@@ -18,32 +18,6 @@ resource "google_compute_url_map" "global" {
   name            = "new-global"
   description     = "direct traffic to the backend service"
   default_service = google_compute_backend_service.global.id
-
-  host_rule {
-    hosts        = [var.domain]
-    path_matcher = "matcher"
-  }
-
-  path_matcher {
-    name = "matcher"
-
-    # Match /v2/* and /token and /chainguard/* and send to the backend service.
-    path_rule {
-      paths   = ["/v2", "/v2/*", "/token", "/chainguard/*"]
-      service = google_compute_backend_service.global.id
-    }
-
-    # Match all other path and redirect to the Chainguard Images marketing page.
-    # See also:
-    # https://cloud.google.com/load-balancing/docs/https/setting-up-global-traffic-mgmt#configure_a_url_redirect
-    default_url_redirect {
-      host_redirect          = "chainguard.dev"
-      https_redirect         = false
-      path_redirect          = "/chainguard-images"
-      redirect_response_code = "TEMPORARY_REDIRECT"
-      strip_query            = true
-    }
-  }
 }
 
 resource "google_compute_target_https_proxy" "global" {
@@ -99,5 +73,5 @@ resource "google_compute_region_network_endpoint_group" "neg" {
 // Enable Compute Engine API.
 resource "google_project_service" "compute" {
   disable_on_destroy = false
-  service = "compute.googleapis.com"
+  service            = "compute.googleapis.com"
 }

--- a/terraform/modules/gclb/gclb.tf
+++ b/terraform/modules/gclb/gclb.tf
@@ -20,7 +20,7 @@ resource "google_compute_url_map" "global" {
   default_service = google_compute_backend_service.global.id
 
   host_rule {
-    hosts        = var.domains
+    hosts        = [var.domain]
     path_matcher = "matcher"
   }
 
@@ -43,24 +43,6 @@ resource "google_compute_url_map" "global" {
       redirect_response_code = "TEMPORARY_REDIRECT"
       strip_query            = true
     }
-  }
-
-  test {
-    service = google_compute_backend_service.global.id
-    host    = "cgr.dev"
-    path    = "/v2/chainguard/static/manifests/latest"
-  }
-
-  test {
-    service = google_compute_backend_service.global.id
-    host    = "cgr.dev"
-    path    = "/chainguard/static:latest"
-  }
-
-  test {
-    service = google_compute_backend_service.global.id
-    host    = "distroless.dev"
-    path    = "/v2/static/manifests/latest"
   }
 }
 

--- a/terraform/modules/gclb/outputs.tf
+++ b/terraform/modules/gclb/outputs.tf
@@ -3,8 +3,5 @@ output "global_ip" {
 }
 
 output "dns-auth" {
-  value = {
-    for auth in google_certificate_manager_dns_authorization.this :
-    auth.domain => auth.dns_resource_record
-  }
+  value = google_certificate_manager_dns_authorization.this.dns_resource_record
 }

--- a/terraform/modules/gclb/variables.tf
+++ b/terraform/modules/gclb/variables.tf
@@ -11,9 +11,6 @@ variable "regions" {
   ]
 }
 
-variable "domains" {
-  type = set(string)
-}
-
-variable "primary_domain" {
+variable "domain" {
+  type = string
 }

--- a/terraform/modules/redirect/redirect.tf
+++ b/terraform/modules/redirect/redirect.tf
@@ -27,12 +27,6 @@ resource "google_cloud_run_service" "regions" {
           name  = "REGION"
           value = each.key
         }
-        args = [
-          "--prefix",
-          "chainguard",
-          "--repo",
-          "chainguard-images",
-        ]
       }
       service_account_name  = google_service_account.sa.email
       container_concurrency = 1000


### PR DESCRIPTION
cgr.dev is now served by our own infrastructure, instead of redirecting to GHCR. This change makes distroless.dev redirect to cgr.dev instead of to GHCR.

This change is staged at redirect.imjasonh.dev, and these requests should work:

```
crane manifest redirect.imjasonh.dev/static
crane pull redirect.imjasonh.dev/static /dev/null
crane ls redirect.imjasonh.dev/static | wc -l
```

(add the `--verbose` flag to see it say that it's proxying to cgr.dev, and redirecting to R2)

This also removes terraform resources for cgr.dev, which are now unused in prod. The cert change may result in a few minutes of downtime for distroless.dev users while the cert provisions.